### PR TITLE
Ensure to pass over decorations as well

### DIFF
--- a/plugin/java_fold.vim
+++ b/plugin/java_fold.vim
@@ -12,7 +12,7 @@ setlocal foldtext=JavaFoldText()
 function! JavaFoldText()
   let nnum = nextnonblank(v:foldstart + 1)
   let nline = getline(nnum)
-  while nline =~ "\*"
+  while (nline =~ "\*" || nline =~ "\s*@")
       let nnum = nextnonblank(nnum + 1)
       let nline = getline(nnum)
   endwhile


### PR DESCRIPTION
When folding methods, do not count `@` decorations as the method signature.